### PR TITLE
Update index.rst

### DIFF
--- a/doc/source/user_api/index.rst
+++ b/doc/source/user_api/index.rst
@@ -186,6 +186,7 @@ them helpful for other purposes.
    wrf.is_multi_file
    wrf.has_time_coord
    wrf.is_mapping
+   wrf.latlon_coords
    wrf.latlon_coordvars
    wrf.is_coordvar
    wrf.get_iterable

--- a/doc/source/user_api/index.rst
+++ b/doc/source/user_api/index.rst
@@ -91,6 +91,7 @@ The routines below are used to assist with plotting.
    :toctree: ./generated/
    
     wrf.geo_bounds
+    wrf.latlon_coords
     wrf.get_cartopy
     wrf.get_basemap
     wrf.get_pyngl
@@ -186,7 +187,6 @@ them helpful for other purposes.
    wrf.is_multi_file
    wrf.has_time_coord
    wrf.is_mapping
-   wrf.latlon_coords
    wrf.latlon_coordvars
    wrf.is_coordvar
    wrf.get_iterable


### PR DESCRIPTION
The plotting documentation contains examples where the `latlon_coords` function is used, but it is not included in the API documentation.