### PR TITLE
Custom vertical dimension in vinterp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,9 @@ test/ipynb/.ipynb_checkpoints
 fortran/omp.f90
 fortran/wrffortran.pyf
 fortran/*.mod
+fortran/_wrffortranmodule.c
+fortran/_wrffortran-f2pywrappers.f
+fortran/_wrffortran-f2pywrappers2.f90
 build
 .settings
 src/wrf_python.egg-info

--- a/src/wrf/interp.py
+++ b/src/wrf/interp.py
@@ -463,7 +463,7 @@ def interpline(field2d, pivot_point=None,
 @set_interp_metadata("vinterp")
 def vinterp(wrfin, field, vert_coord, interp_levels, extrapolate=False, 
             field_type=None, log_p=False, timeidx=0, method="cat", 
-            squeeze=True, cache=None, meta=True):
+            squeeze=True, cache=None, meta=True, **kwargs):
     """Return the field vertically interpolated to the given the type of 
     surface and a set of new levels.
     

--- a/src/wrf/metadecorators.py
+++ b/src/wrf/metadecorators.py
@@ -1346,8 +1346,9 @@ def _set_vinterp_meta(wrapped, instance, args, kwargs):
         except KeyError:
             pass # xarray 0.9
         
-        outdimnames.insert(-2, "interp_level")
-        outcoords["interp_level"] = interp_levels
+        newdimname = kwargs.get("vdim_name", "interp_level")
+        outdimnames.insert(-2, newdimname)
+        outcoords[newdimname] = interp_levels
         outattrs.update(field.attrs)
         
         


### PR DESCRIPTION
Allow wrf.vinterp() use a custom name for the vertical dimension it creates, instead of the default `interp_level`.

Fixes #54