### PR TITLE
Bootstrap numpy installation in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,14 @@ import sys
 import setuptools
 import socket
 
+# Bootstrap a numpy installation before trying to import it.
+import imp
+try:
+    imp.find_module('numpy')
+except ImportError:
+    import subprocess
+    subprocess.call([sys.executable, '-m', 'pip', 'install', 'numpy'])
+
 if not socket.gethostname().startswith("cheyenne"):
     import numpy.distutils.core
 else:


### PR DESCRIPTION
### The Issue
Currently there is a bootstrapping issue for using `numpy` in `setup.py`. When trying to pip install `wrf-python` in a fresh python environment, I receive the following error:
```
$ pip install git+https://github.com/NCAR/wrf-python.git
Collecting git+https://github.com/NCAR/wrf-python.git
  Cloning https://github.com/NCAR/wrf-python.git to /private/var/folders/s4/98n8gz0n32b1glmrsb24jbjm0000gn/T/pip-req-build-aukdrz56
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/private/var/folders/s4/98n8gz0n32b1glmrsb24jbjm0000gn/T/pip-req-build-aukdrz56/setup.py", line 7, in <module>
        import numpy.distutils.core
    ModuleNotFoundError: No module named 'numpy'
    
    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /private/var/folders/s4/98n8gz0n32b1glmrsb24jbjm0000gn/T/pip-req-build-aukdrz56/
```
This is because although you are declaring `numpy` in requirements.txt and the `install_requires` parameter of `numpy.distutils.core.setup`, the import of `numpy.distutils.core` is occurring before pip can resolve the dependency.

While the easy solution is to just install `numpy` prior to trying to install `wrf-python` this becomes complicated when trying to integrate this project into other projects since pip does not support sequential installation.

### Proposed Solution
Check if `numpy` is installed prior to trying to import it and if `numpy` does not exist, force pip to install it.
With this solution:
```
$ pip install git+https://github.com/bbonenfant/wrf-python.git
Collecting git+https://github.com/bbonenfant/wrf-python.git
  Cloning https://github.com/bbonenfant/wrf-python.git to /private/var/folders/s4/98n8gz0n32b1glmrsb24jbjm0000gn/T/pip-req-build-h1exoa0z
Requirement already satisfied: numpy>=1.11 in /Users/bbonenfant/wrf-venv/lib/python3.6/site-packages (from wrf-python==1.3.1) (1.16.0)
Collecting wrapt (from wrf-python==1.3.1)
Requirement already satisfied: setuptools in /Users/bbonenfant/wrf-venv/lib/python3.6/site-packages (from wrf-python==1.3.1) (40.6.3)
Building wheels for collected packages: wrf-python
  Running setup.py bdist_wheel for wrf-python ... done
  Stored in directory: /private/var/folders/s4/98n8gz0n32b1glmrsb24jbjm0000gn/T/pip-ephem-wheel-cache-m3ben7fc/wheels/6c/5c/26/96d651be2c3d7dc2852f55a1c3522f83253befae47d3549932
Successfully built wrf-python
Installing collected packages: wrapt, wrf-python
Successfully installed wrapt-1.11.1 wrf-python-1.3.1
```