### PR TITLE
fix docstring for `interplevel` func

### DIFF
--- a/src/wrf/interp.py
+++ b/src/wrf/interp.py
@@ -93,7 +93,7 @@ def interplevel(field3d, vert, desiredlev, missing=default_fill(np.float64),
             z = getvar(wrfin, "z")
             pblh = getvar(wrfin, "PBLH")
 
-            rh_pblh = interplevel(rh, p, pblh)
+            rh_pblh = interplevel(rh, z, pblh)
 
 
     """


### PR DESCRIPTION
This PR fixes the typo in the example for the `interplevel` function.
The smallest PR you've ever come across -- probably...