### PR TITLE
Library "collections" causes FutureWarning.

### DIFF
--- a/src/wrf/constants.py
+++ b/src/wrf/constants.py
@@ -16,7 +16,7 @@ class Constants(object):
 
 
 for key, val in viewitems(wrf_constants.__dict__):
-    setattr(Constants, key.upper(), np.asscalar(val))
+    setattr(Constants, key.upper(), val.item())
 
 OMP_SCHED_STATIC = omp_constants.fomp_sched_static
 OMP_SCHED_DYNAMIC = omp_constants.fomp_sched_dynamic

--- a/src/wrf/decorators.py
+++ b/src/wrf/decorators.py
@@ -1,6 +1,7 @@
 from __future__ import (absolute_import, division, print_function)
 
-from collections import Iterable, OrderedDict
+from collections import OrderedDict
+from collections.abc import Iterable
 
 import wrapt
 import numpy as np

--- a/src/wrf/latlonutils.py
+++ b/src/wrf/latlonutils.py
@@ -1,6 +1,6 @@
 from __future__ import (absolute_import, division, print_function)
 
-from collections import Iterable
+from collections.abc import Iterable
 
 import numpy as np
 

--- a/src/wrf/util.py
+++ b/src/wrf/util.py
@@ -3,7 +3,8 @@ from __future__ import (absolute_import, division, print_function)
 import os
 from sys import version_info
 from copy import copy
-from collections import Iterable, Mapping, OrderedDict
+from collections import OrderedDict
+from collections.abc import Iterable, Mapping
 from itertools import product, tee
 from types import GeneratorType
 import datetime as dt


### PR DESCRIPTION
So far, we encounter only FutureWarning.
However, in the future, wrf-python will not work because of the change in the structure of Library "collections".
In order to avoid FutureWarning, I change codes a bit. 