### PR TITLE
Updating contributor's guide

### DIFF
--- a/doc/source/contrib.rst
+++ b/doc/source/contrib.rst
@@ -37,7 +37,7 @@ that when you first clone the repository, you will be on the
 
 Since you will be submitting pull requests for your contributions, you don't 
 really need to know much about GitFlow, other than making sure that you 
-are not developing off of the master branch.
+are not developing off of the main branch.
 
   
 Ways to Contribute


### PR DESCRIPTION
Updating to reflect the branch name change from 'master' to 'main'

This branch is comparing to ```main``` not ```develop```, so approving should merge/publish changes immediately