### PR TITLE
Update Mercator projection attributes

### DIFF
--- a/src/wrf/projection.py
+++ b/src/wrf/projection.py
@@ -76,12 +76,9 @@ if cartopy_enabled():
                 else:
                     xlimits[0] = -xlimits[0]
 
-            self._xlimits = tuple(xlimits)
-            self._ylimits = tuple(limits[..., 1])
-
             # Compatibility with cartopy >= 0.17
-            self._x_limits = self._xlimits
-            self._y_limits = self._ylimits
+            self._x_limits = tuple(xlimits)
+            self._y_limits =  tuple(limits[..., 1])
 
             self._threshold = np.diff(self.x_limits)[0] / 720
 


### PR DESCRIPTION
Addresses Issue #162 

Removes previous self._xlimits and self._ylimits as Cartopy dropped support for them after 0.17, fixes by using self._x_limits and self._y_limits (Cartopy compliant). 

Some points I think are worth noting for this PR:
- In case of future user issues, I think we should drop support for Cartopy <= 0.20 as there were other major updates to Cartopy (and it's dependencies) that would make versions before 0.20 not work, but this will also reduce the scope of potential issues with any users who may be using very outdated versions of Cartopy.
- I came across some interesting behaviors with this repo (specifically with fortran code) when to trying to create new tests and needed to instead do a very long winded work around between two environments and testing with code in the wrf-python tutorial repo, so this is possibly something we need to address going forward. This is also why you won't see a true test file for this bug fix, but I would be more than happy to show the outputs from my testing work around.