### PR TITLE
Mercator fix

### DIFF
--- a/src/wrf/g_slp.py
+++ b/src/wrf/g_slp.py
@@ -63,7 +63,7 @@ def get_slp(wrfin, timeidx=0, method="cat", squeeze=True,
 
         units (:obj:`str`): The desired units.  Refer to the :meth:`getvar`
             product table for a list of available units for 'slp'.  Default
-            is 'Pa'.
+            is 'hPa'.
 
     Returns:
 

--- a/src/wrf/projection.py
+++ b/src/wrf/projection.py
@@ -20,74 +20,73 @@ if pyngl_enabled():
 
 
 if cartopy_enabled():
-    if cartopy_enabled():
-        class MercatorWithLatTS(crs.Mercator):
-            """A :class:`cartopy.crs.Mercator` subclass that adds support for
-            a latitude of true scale parameter.
+    class MercatorWithLatTS(crs.Mercator):
+        """A :class:`cartopy.crs.Mercator` subclass that adds support for
+        a latitude of true scale parameter.
 
-            See Also:
+        See Also:
 
-                :class:`cartopy.crs.Mercator`
+            :class:`cartopy.crs.Mercator`
+
+        """
+        def __init__(self, central_longitude=0.0,
+                     latitude_true_scale=0.0,
+                     min_latitude=-80.0,
+                     max_latitude=84.0,
+                     globe=None):
+            """Initialize a :class:`wrf.MercatorWithLatTS` object.
+
+            Args:
+
+                central_longitude (:obj:`float`, optional): The central
+                    longitude.  Default is 0.0.
+
+                latitude_true_scale (:obj:`float`, optional): The latitude
+                    of true scale.  Default is 0.0.
+
+                min_latitude (:obj:`float`, optional): The maximum southerly
+                    extent of the projection.  Default is -80.0.
+
+                max_latitude (:obj:`float`, optional): The maximum northerly
+                    extent of the projection.  Default is 84.0.
+
+                globe (:class:`cartopy.crs.Globe`, optional): A globe object.
+                    If omitted, a default globe is created.
 
             """
-            def __init__(self, central_longitude=0.0,
-                         latitude_true_scale=0.0,
-                         min_latitude=-80.0,
-                         max_latitude=84.0,
-                         globe=None):
-                """Initialize a :class:`wrf.MercatorWithLatTS` object.
+            proj4_params = [("proj", "merc"),
+                            ("lon_0", central_longitude),
+                            ("lat_ts", latitude_true_scale),
+                            ("k", 1),
+                            ("units", "m")]
+            super(crs.Mercator, self).__init__(proj4_params, globe=globe)
 
-                Args:
+            # Need to have x/y limits defined for the initial hash which
+            # gets used within transform_points for caching
+            self._x_limits = self._y_limits = None
 
-                    central_longitude (:obj:`float`, optional): The central
-                        longitude.  Default is 0.0.
+            # Calculate limits.
+            limits = self.transform_points(
+                crs.Geodetic(),
+                np.array([-180, 180]) + central_longitude,
+                np.array([min_latitude, max_latitude]))
 
-                    latitude_true_scale (:obj:`float`, optional): The latitude
-                        of true scale.  Default is 0.0.
+            # When using a latitude of true scale, the min/max x-limits get set
+            # to the same value, so make sure the left one is negative
+            xlimits = limits[..., 0]
 
-                    min_latitude (:obj:`float`, optional): The maximum southerly
-                        extent of the projection.  Default is -80.0.
+            if math.fabs(xlimits[0] - xlimits[1]) < 1e-6:
+                if xlimits[0] < 0:
+                    xlimits[1] = -xlimits[1]
+                else:
+                    xlimits[0] = -xlimits[0]
 
-                    max_latitude (:obj:`float`, optional): The maximum northerly
-                        extent of the projection.  Default is 84.0.
+            # Compatibility with cartopy >= 0.17
+            self._x_limits = tuple(xlimits)
+            self._y_limits =  tuple(limits[..., 1])
 
-                    globe (:class:`cartopy.crs.Globe`, optional): A globe object.
-                        If omitted, a default globe is created.
-
-                """
-                proj4_params = [("proj", "merc"),
-                                ("lon_0", central_longitude),
-                                ("lat_ts", latitude_true_scale),
-                                ("k", 1),
-                                ("units", "m")]
-                super(crs.Mercator, self).__init__(proj4_params, globe=globe)
-
-                # Need to have x/y limits defined for the initial hash which
-                # gets used within transform_points for caching
-                self._x_limits = self._y_limits = None
-
-                # Calculate limits.
-                limits = self.transform_points(
-                    crs.Geodetic(),
-                    np.array([-180, 180]) + central_longitude,
-                    np.array([min_latitude, max_latitude]))
-
-                # When using a latitude of true scale, the min/max x-limits get set
-                # to the same value, so make sure the left one is negative
-                xlimits = limits[..., 0]
-
-                if math.fabs(xlimits[0] - xlimits[1]) < 1e-6:
-                    if xlimits[0] < 0:
-                        xlimits[1] = -xlimits[1]
-                    else:
-                        xlimits[0] = -xlimits[0]
-
-                # Compatibility with cartopy >= 0.17
-                self._x_limits = tuple(xlimits)
-                self._y_limits =  tuple(limits[..., 1])
-
-                self._threshold = min(np.diff(self.x_limits)[0] / 720,
-                                      np.diff(self.y_limits)[0] / 360)
+            self._threshold = min(np.diff(self.x_limits)[0] / 720,
+                                  np.diff(self.y_limits)[0] / 360)
 
 
 def _ismissing(val, islat=True):

--- a/src/wrf/projection.py
+++ b/src/wrf/projection.py
@@ -824,7 +824,7 @@ class PolarStereographic(WrfProj):
 
     def _proj4(self):
         _proj4 = ("+proj=stere +units=m +a={} +b={} "
-                  "+lat0={} +lon_0={} +lat_ts={} +nadgrids=@null".format(
+                  "+lat_0={} +lon_0={} +lat_ts={} +nadgrids=@null".format(
                                             Constants.WRF_EARTH_RADIUS,
                                             Constants.WRF_EARTH_RADIUS,
                                             self._hemi,

--- a/src/wrf/projection.py
+++ b/src/wrf/projection.py
@@ -76,12 +76,9 @@ if cartopy_enabled():
                 else:
                     xlimits[0] = -xlimits[0]
 
-            self._xlimits = tuple(xlimits)
-            self._ylimits = tuple(limits[..., 1])
-
             # Compatibility with cartopy >= 0.17
-            self._x_limits = self._xlimits
-            self._y_limits = self._ylimits
+            self._x_limits = tuple(xlimits)
+            self._y_limits =  tuple(limits[..., 1])
 
             self._threshold = np.diff(self.x_limits)[0] / 720
 


### PR DESCRIPTION
Should address the issue users are having when using Mercator projections in their wrfout files (seen in and closes #173). PR is set to merge directly to main as we have nothing else that would need to be released via a merge of develop into main. 

Tested this by uninstalling wrf-python in my conda environment, making changes to the file on the branch, running `pip install .` to install from source, then testing with a scratch file using a wrfout file that has a Mercator projection type. Cartopy version in environment is 0.20.2, which is the same version that was giving problems to users. Please feel free to test this locally as well before approving. I can send over the relevant code and wrfout file if necessary!