### PR TITLE
Removes Cartopy from Requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 basemap
-cartopy>0.17
 numpy>=1.11
 setuptools
 wrapt


### PR DESCRIPTION
RTD builds were failing due to having Cartopy listed in requirements.txt. Tested on branch "build_tests", which passed when built. Will test this branch as well before merge.

Edit: Build was successful on RTD 