### PR TITLE
Fixing setup.py (install numpy)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,8 @@ ext1 = numpy.distutils.core.Extension(
              "fortran/omp.f90"]
     )
 
+#Note: __version__ will be set in the version.py script loaded below
+__version__ = None
 with open("src/wrf/version.py") as f:
     exec(f.read())
 

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ numpy.distutils.core.setup(
                       "GitHub Repository:\n\n"
                       "https://github.com/NCAR/wrf-python\n\n"
                       "Documentation:\n\n"
-                      "http://wrf-python.rtfd.org\n"),
+                      "https://wrf-python.rtfd.org\n"),
     url="https://github.com/NCAR/wrf-python",
     version=__version__,
     package_dir={"": "src"},
@@ -112,7 +112,7 @@ numpy.distutils.core.setup(
     license="Apache License 2.0",
     packages=setuptools.find_packages("src"),
     ext_modules=ext_modules,
-    download_url="http://python.org/pypi/wrf-python",
+    download_url="https://python.org/pypi/wrf-python",
     package_data={"wrf": ["data/psadilookup.dat"]},
     scripts=[]
 )

--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,10 @@ import socket
 # Bootstrap a numpy installation before trying to import it.
 import importlib
 try:
-    importlib.util.find_spec('numpy')
-except ImportError:
+    numpy_module = importlib.util.find_spec('numpy')
+    if numpy_module is None:
+        raise ModuleNotFoundError
+except (ImportError, ModuleNotFoundError):
     import subprocess
     subprocess.call([sys.executable, '-m', 'pip', 'install', 'numpy'])
 


### PR DESCRIPTION
Hi,

I noticed that in the last release it had a GitHub Action to deploy to PYPI, but looks like that's still not working (related to #170 & #176).

I imported the project into PyCharm, fixed a couple warnings, and then had the same error from GitHub Actions. In GH Actions, the error is as below.

![image](https://user-images.githubusercontent.com/304786/169237717-d02b7ac7-2bac-43da-8e92-85fb350aa1ad.png)

Reproduced locally on a fresh virtual environment.

```bash
(venv) kinow@ranma:~/Development/python/workspace/wrf-python$ pip install -e .
Obtaining file:///home/kinow/Development/python/workspace/wrf-python
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error
  
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [7 lines of output]
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "/home/kinow/Development/python/workspace/wrf-python/setup.py", line 16, in <module>
          import numpy.distutils.core
      ModuleNotFoundError: No module named 'numpy'
      Says: None
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
```

The issue is that we were expecting `importlib.util.find_spec('numpy')` to raise an error, but since 3.4  (was `find_module` I believe) it [returns `None`](https://docs.python.org/3/library/importlib.html) when the module is not found.

![image](https://user-images.githubusercontent.com/304786/169238101-6734a4b3-929f-4db6-8df2-0098510db0b8.png)

I simply raised the exception when the module returned is None, and that fixed the installation on my environment. Tested that running the installation again doesn't raise the issue.

Cheers,
Bruno