### PR TITLE
Update citation texts to reflect Zenodo per-version DOI creation

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,7 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+authors:
+  - given-names: "Visualization & Analysis Systems Technologies"
+title: "Geoscience Community Analysis Toolkit: WRF-Python"
+doi: 10.5065/D6W094P1
+url: "https://github.com/NCAR/wrf-python"

--- a/README.md
+++ b/README.md
@@ -20,9 +20,8 @@ http://wrf-python.rtfd.org
 Citation
 ------------------
 
-    Ladwig, W. (2017). wrf-python (Version x.x.x) [Software]. Boulder, Colorado: UCAR/NCAR. https://doi.org/10.5065/D6W094P1 
-    
-Note: The version number x.x.x should be set to the version of wrf-python that you are using.
+If you use this software, please cite it as described at the [WRF-Python - Citation](
+https://wrf-python.readthedocs.io/en/latest/citation.html) page.
 
 
 --------------------

--- a/doc/source/citation.rst
+++ b/doc/source/citation.rst
@@ -1,26 +1,49 @@
 .. _citation:
 
 Citation
-=================
+==========
 
-WRF-Python has a Digital Object Identifier (DOI), which is a persistent 
-identifier for web-based resources. The wrf-python DOI, when used in URL form, 
-https://doi.org/10.5065/D6W094P1, provides a persistent link to the wrf-python 
-Github page. The benefit of DOIs is that they are widely accepted by academic 
-publishers as citable locators for scholarly objects.
+How to cite WRF-Python
+-----------------------
 
-If you author a paper that involves data analysis with wrf-python, or 
-visualizations created with wrf-python, we would like to ask you to please 
-cite wrf-python. This helps us better understand the impact of the software on 
-the scientific community, which in turns helps us maintain support for the 
-effort.
+If you use this software, please cite it as described below:
 
-You can cite wrf-python using the following citation:
+WRF-Python has a Digital Object Identifier (DOI), which is a persistent identifier for
+web-based resources. The benefit of DOIs is that they are widely accepted by academic publishers
+as citable locators for scholarly objects. The WRF-Python DOI, when used in URL form,
+`https://doi.org/10.5065/D6W094P1 <https://doi.org/10.5065/D6W094P1>`_, provides a persistent link
+to the WRF-Python GitHub repository, and can be used to cite the WRF-Python project as a whole.
 
-.. code-block:: none
+In addition, each WRF-Python version is assigned a separate DOI to allow users to access older
+releases. This ensures that users are not only able to cite the specific software version through
+DOIs but are also able to download & use the corresponding release for reproducibility purposes.
 
-   Ladwig, W. (2017). wrf-python (Version x.x.x) [Software]. Boulder, Colorado: UCAR/NCAR. https://doi.org/10.5065/D6W094P1 
-    
-.. note:: 
+If you would like to cite WRF-Python as a whole (without referring to a specific version), use
+the following text:
 
-   The version number x.x.x should be set to the version of wrf-python that you are using.
+**Visualization & Analysis Systems Technologies. (2017).
+Geoscience Community Analysis Toolkit: WRF-Python [Software].
+Boulder, CO: UCAR/NCAR - Computational and Informational System Lab. doi:10.5065/D6W094P1.**
+
+Instead, if you would like to cite a specific version of WRF-Python, use the following text:
+
+**Visualization & Analysis Systems Technologies. (Year).
+Geoscience Community Analysis Toolkit: WRF-Python (v\<version\>) [Software].
+Boulder, CO, USA: UCAR/NCAR - Computational and Informational System Lab. doi:\<DOI\>.**
+
+In the above citation text, update the year, WRF-Python version, and DOI as appropriate. For
+example:
+
+**Visualization & Analysis Systems Technologies. (2022).
+Geoscience Community Analysis Toolkit: WRF-Python (v1.3.4.1) [Software].
+Boulder, CO, USA: UCAR/NCAR - Computational and Informational System Lab. doi:10.5281/zenodo.6685115.**
+
+Please find DOIs for all the WRF-Python versions `here
+<https://zenodo.org/search?page=1&size=20&q=conceptrecid:%226685091%22&sort=-version&all_versions=True>`_.
+
+Please note: The DOI minting service, Zenodo, might be suggesting their own citation text (as
+they are the publisher of such DOIs) in their website. We prefer the text we recommend here to be used;
+however, either way is acceptable.
+
+For further information, please refer to
+`GeoCAT homepage - Citation <https://geocat.ucar.edu/pages/citation.html>`_.


### PR DESCRIPTION
We are starting to generate DOIs for each GeoCAT-comp version via the Zenodo minting service. Texts regarding citation are updated to reflect this change. See [GeoCAT-comp PR#224](https://github.com/NCAR/geocat-comp/pull/224) for reference.