### PR TITLE
Add alias for mcape and mcin

### DIFF
--- a/src/wrf/routines.py
+++ b/src/wrf/routines.py
@@ -196,6 +196,8 @@ _ALIASES = {"cape_2d": "cape2d",
             "wdir_uvmet": "uvmet_wdir",
             "wspd_uvmet10": "uvmet10_wspd",
             "wdir_uvmet10": "uvmet10_wdir",
+            "mcape": "cape2d_only",
+            "mcin": "cin2d_only"
             }
 
 


### PR DESCRIPTION
As I commented in #194 calling variables mcape and mcin in getvar function gives an error. I added the alias for those variables to make it work.