### PR TITLE
PKG: Require python to be old enough for numpy.distutils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ numpy.distutils.core.setup(
               "plotting", "plots", "meteorology", "nwp",
               "numerical weather prediction", "diagnostic",
               "science", "numpy"],
-    python_requires='>=3.7',
+    python_requires='>=3.7, <3.12',
     install_requires=requirements,
     classifiers=["Development Status :: 5 - Production/Stable",
                  "Intended Audience :: Science/Research",


### PR DESCRIPTION
[numpy.distutils will never be on Python 3.12](https://numpy.org/doc/stable/reference/distutils_status_migration.html), but the build script makes heavy use of it.  This PR adds this requirement to the metadata.