### PR TITLE
BLD: Add pyproject.toml

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,7 +11,7 @@ build:
     python: "mambaforge-4.10"
   jobs:
     post_create_environment:
-      - python -m pip install --no-cache-dir .
+      - python -m pip install --no-cache-dir --no-deps .
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,5 @@
 include README.md
 include LICENSE
-include requirements.txt
 
 include fortran/*.f90
 include fortran/*.pyf

--- a/build_scripts/gnu_omp.sh
+++ b/build_scripts/gnu_omp.sh
@@ -11,6 +11,7 @@ $FC -E ompgen.F90 -fopenmp -cpp -o omp.f90
 cd ..
 
 python setup.py clean --all
+export LDFLAGS=" -fopenmp "
 python setup.py config_fc --f90flags="-mtune=generic -fopenmp" build_ext --libraries="gomp" build
 pip install .
 

--- a/fortran/omp.f90
+++ b/fortran/omp.f90
@@ -7,6 +7,9 @@ MODULE omp_constants
     INTEGER(KIND=fomp_sched_kind), PARAMETER :: fomp_sched_dynamic = 2
     INTEGER(KIND=fomp_sched_kind), PARAMETER :: fomp_sched_guided = 3
     INTEGER(KIND=fomp_sched_kind), PARAMETER :: fomp_sched_auto = 4
+contains
+  subroutine have_omp_constants()
+  end subroutine have_omp_constants
 END MODULE omp_constants
 
 

--- a/fortran/ompgen.F90
+++ b/fortran/ompgen.F90
@@ -20,6 +20,10 @@ MODULE omp_constants
     INTEGER(KIND=4), PARAMETER :: fomp_sched_auto = 4
 #endif
 
+contains
+  subroutine have_omp_constants()
+  end subroutine have_omp_constants
+
 END MODULE omp_constants
 
 

--- a/fortran/ompgen.F90.template
+++ b/fortran/ompgen.F90.template
@@ -20,6 +20,10 @@ MODULE omp_constants
     INTEGER(KIND=4), PARAMETER :: fomp_sched_auto = 4
 #endif
 
+contains
+  subroutine have_omp_constants()
+  end subroutine have_omp_constants
+
 END MODULE omp_constants
 
 

--- a/fortran/wrf_constants.f90
+++ b/fortran/wrf_constants.f90
@@ -69,6 +69,9 @@ MODULE wrf_constants
     REAL(KIND=8), PARAMETER :: EXPON =  RD*USSALR/G
     REAL(KIND=8), PARAMETER :: EXPONI =  1./EXPON
 
+  contains
+    subroutine have_wrf_constants()
+    end subroutine have_wrf_constants
 
 END MODULE wrf_constants
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,9 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "wrf-python"
-authors = ["Bill Ladwig"]
+authors = [
+    { name = "Bill Ladwig" }
+]
 maintainers = [
     { name = "GeoCAT", email = "geocat@ucar.edu" },
 ]
@@ -34,7 +36,7 @@ classifiers = [
     "Operating System :: MacOS",
     "Operating System :: Microsoft :: Windows"
 ]
-license = { text = "Apache-2.0", file = "LICENSE" }
+license = { text = "Apache-2.0" }
 dynamic = [ "version", "dependencies" ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,53 @@
+[build-system]
+requires = ["setuptools", "numpy"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "wrf-python"
+authors = ["Bill Ladwig"]
+maintainers = [
+    { name = "GeoCAT", email = "geocat@ucar.edu" },
+]
+description = "Diagnostic and interpolation routines for WRF-ARW data."
+readme = "README.md"
+requires-python = ">=3.7, <3.12"
+keywords = [
+    "python", "wrf-python", "wrf", "forecast", "model",
+    "weather research and forecasting", "interpolation",
+    "plotting", "plots", "meteorology", "nwp",
+    "numerical weather prediction", "diagnostic",
+    "science", "numpy"
+]
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: Science/Research",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Fortran",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Topic :: Scientific/Engineering :: Atmospheric Science",
+    "Topic :: Software Development",
+    "Operating System :: POSIX",
+    "Operating System :: Unix",
+    "Operating System :: MacOS",
+    "Operating System :: Microsoft :: Windows"
+]
+license = { text = "Apache-2.0", file = "LICENSE" }
+dynamic = [ "version", "dependencies" ]
+
+[project.urls]
+Repository = "https://github.com/NCAR/wrf-python"
+Documentation = "https://wrf-python.rtfd.org"
+
+[tool.setuptools]
+package-data = { "wrf" = ["data/psadilookup.dat"]}
+platforms = ["any"]
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.setuptools.dynamic]
+version = { attr = "wrf.version.__version__" }
+dependencies = { file = "requirements.txt" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61, <=70.0", "numpy"]
+requires = ["setuptools>=61", "numpy"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61", "numpy"]
+requires = ["setuptools>=61", "numpy<2.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -40,7 +40,7 @@ license = { text = "Apache-2.0" }
 dynamic = [ "version" ]
 dependencies = [
     "basemap",
-    "numpy >=1.11, !=1.24.3",
+    "numpy >=1.11, !=1.24.3, <2.0",
     "setuptools",
     "wrapt",
     "xarray"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools<60", "numpy<2.0"]
+requires = ["setuptools>=61, <=70.0", "numpy<2.0"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=60", "numpy"]
+requires = ["setuptools>=61", "numpy"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -37,7 +37,14 @@ classifiers = [
     "Operating System :: Microsoft :: Windows"
 ]
 license = { text = "Apache-2.0" }
-dynamic = [ "version", "dependencies" ]
+dynamic = [ "version" ]
+dependencies = [
+    "basemap",
+    "numpy >=1.11, !=1.24.3",
+    "setuptools",
+    "wrapt",
+    "xarray"
+]
 
 [project.urls]
 Repository = "https://github.com/NCAR/wrf-python"
@@ -52,4 +59,3 @@ where = ["src"]
 
 [tool.setuptools.dynamic]
 version = { attr = "wrf.version.__version__" }
-dependencies = { file = "requirements.txt" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61", "numpy"]
+requires = ["setuptools>=61, <70", "numpy"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "numpy"]
+requires = ["setuptools>=60", "numpy"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61, <=70.0", "numpy<2.0"]
+requires = ["setuptools>=61, <=70.0", "numpy"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -40,7 +40,7 @@ license = { text = "Apache-2.0" }
 dynamic = [ "version" ]
 dependencies = [
     "basemap",
-    "numpy >=1.11, !=1.24.3, <2.0",
+    "numpy >=1.11, !=1.24.3",
     "setuptools",
     "wrapt",
     "xarray"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61", "numpy<2.0"]
+requires = ["setuptools<60", "numpy<2.0"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,0 @@
-basemap
-numpy >=1.11, !=1.24.3
-setuptools
-wrapt
-xarray

--- a/setup.py
+++ b/setup.py
@@ -45,14 +45,9 @@ ext1 = numpy.distutils.core.Extension(
 on_rtd = os.environ.get("READTHEDOCS", None) == "True"
 # on_rtd=True
 if on_rtd:
-    requirements = ['mock; python_version < "3.3"']
     ext_modules = []
 
 else:
-    # Place install_requires into the text file "requirements.txt"
-    with open("requirements.txt") as f2:
-        requirements = f2.read().strip().splitlines()
-
     ext_modules = [ext1]
 
 numpy.distutils.core.setup(

--- a/setup.py
+++ b/setup.py
@@ -1,17 +1,6 @@
 import os
-import sys
 import setuptools
 import socket
-
-# Bootstrap a numpy installation before trying to import it.
-import importlib
-try:
-    numpy_module = importlib.util.find_spec('numpy')
-    if numpy_module is None:
-        raise ModuleNotFoundError
-except (ImportError, ModuleNotFoundError):
-    import subprocess
-    subprocess.call([sys.executable, '-m', 'pip', 'install', 'numpy'])
 
 if not socket.gethostname().startswith("cheyenne"):
     import numpy.distutils.core
@@ -53,18 +42,10 @@ ext1 = numpy.distutils.core.Extension(
              "fortran/omp.f90"]
     )
 
-#Note: __version__ will be set in the version.py script loaded below
-__version__ = None
-with open("src/wrf/version.py") as f:
-    exec(f.read())
-
 on_rtd = os.environ.get("READTHEDOCS", None) == "True"
 # on_rtd=True
 if on_rtd:
-    if sys.version_info < (3, 3):
-        requirements = ["mock"]  # for python2 and python < 3.3
-    else:
-        requirements = []  # for >= python3.3
+    requirements = ["mock; python_version < 3.3"]
     ext_modules = []
 
 else:
@@ -72,51 +53,10 @@ else:
     with open("requirements.txt") as f2:
         requirements = f2.read().strip().splitlines()
 
-        # if sys.version_info < (3,3):
-        #     requirements.append("mock")
     ext_modules = [ext1]
 
 numpy.distutils.core.setup(
-    name='wrf-python',
-    author="Bill Ladwig",
-    maintainer="GeoCAT",
-    maintainer_email="geocat@ucar.edu",
-    description="Diagnostic and interpolation routines for WRF-ARW data.",
-    long_description=("A collection of diagnostic and interpolation "
-                      "routines to be used with WRF-ARW data.\n\n"
-                      "GitHub Repository:\n\n"
-                      "https://github.com/NCAR/wrf-python\n\n"
-                      "Documentation:\n\n"
-                      "https://wrf-python.rtfd.org\n"),
-    url="https://github.com/NCAR/wrf-python",
-    version=__version__,
-    package_dir={"": "src"},
-    keywords=["python", "wrf-python", "wrf", "forecast", "model",
-              "weather research and forecasting", "interpolation",
-              "plotting", "plots", "meteorology", "nwp",
-              "numerical weather prediction", "diagnostic",
-              "science", "numpy"],
-    python_requires='>=3.7',
     install_requires=requirements,
-    classifiers=["Development Status :: 5 - Production/Stable",
-                 "Intended Audience :: Science/Research",
-                 "Intended Audience :: Developers",
-                 "License :: OSI Approved :: Apache Software License",
-                 "Programming Language :: Fortran",
-                 "Programming Language :: Python :: 3.9",
-                 "Programming Language :: Python :: 3.10",
-                 "Programming Language :: Python :: 3.11",
-                 "Topic :: Scientific/Engineering :: Atmospheric Science",
-                 "Topic :: Software Development",
-                 "Operating System :: POSIX",
-                 "Operating System :: Unix",
-                 "Operating System :: MacOS",
-                 "Operating System :: Microsoft :: Windows"],
-    platforms=["any"],
-    license="Apache License 2.0",
-    packages=setuptools.find_packages("src"),
     ext_modules=ext_modules,
-    download_url="https://python.org/pypi/wrf-python",
-    package_data={"wrf": ["data/psadilookup.dat"]},
     scripts=[]
 )

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ ext1 = numpy.distutils.core.Extension(
 on_rtd = os.environ.get("READTHEDOCS", None) == "True"
 # on_rtd=True
 if on_rtd:
-    requirements = ["mock; python_version < 3.3"]
+    requirements = ['mock; python_version < "3.3"']
     ext_modules = []
 
 else:

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,6 @@ else:
     ext_modules = [ext1]
 
 numpy.distutils.core.setup(
-    install_requires=requirements,
     ext_modules=ext_modules,
     scripts=[]
 )


### PR DESCRIPTION
This might close #237 by specifying NumPy as a build dependency before starting the setup script.

I moved as much configuration to `pyproject.toml` as I could as an initial step to converting the build to a system available on Python 3.12.  