### PR TITLE
Remove np.float_ as a fill option

### DIFF
--- a/build_envs/environment.yml
+++ b/build_envs/environment.yml
@@ -11,6 +11,7 @@ dependencies:
   - matplotlib
   - netcdf4
   - numpy
+  - packaging
   - pycodestyle
   - setuptools
   - sphinx

--- a/src/wrf/constants.py
+++ b/src/wrf/constants.py
@@ -59,7 +59,6 @@ _DEFAULT_FILL_MAP = {None: Constants.DEFAULT_FILL,
                      np.dtype(np.uint32): 4294967295,
                      np.dtype(np.int64): Constants.DEFAULT_FILL_INT64,
                      np.dtype(np.uint64): 18446744073709551614,
-                     np.dtype(np.float_): Constants.DEFAULT_FILL_DOUBLE,
                      np.dtype(np.float32): Constants.DEFAULT_FILL_FLOAT,
                      np.dtype(np.float64): Constants.DEFAULT_FILL_DOUBLE
                      }

--- a/src/wrf/constants.py
+++ b/src/wrf/constants.py
@@ -7,6 +7,9 @@ import numpy as np
 from .py3compat import viewitems
 from ._wrffortran import wrf_constants, omp_constants
 
+from packaging.version import Version
+np_version = Version(np.__version__)
+
 #: Indicates that all times should be used in a diagnostic routine.
 ALL_TIMES = None
 
@@ -62,6 +65,9 @@ _DEFAULT_FILL_MAP = {None: Constants.DEFAULT_FILL,
                      np.dtype(np.float32): Constants.DEFAULT_FILL_FLOAT,
                      np.dtype(np.float64): Constants.DEFAULT_FILL_DOUBLE
                      }
+
+if np_version < Version('2.0'):
+    _DEFAULT_FILL_MAP[np.float_] = Constants.Constants.DEFAULT_FILL_DOUBLE
 
 if version_info >= (3, ):
     _DEFAULT_FILL_MAP[np.int_] = Constants.DEFAULT_FILL_INT64

--- a/src/wrf/constants.py
+++ b/src/wrf/constants.py
@@ -7,9 +7,6 @@ import numpy as np
 from .py3compat import viewitems
 from ._wrffortran import wrf_constants, omp_constants
 
-from packaging.version import Version
-np_version = Version(np.__version__)
-
 #: Indicates that all times should be used in a diagnostic routine.
 ALL_TIMES = None
 
@@ -66,8 +63,10 @@ _DEFAULT_FILL_MAP = {None: Constants.DEFAULT_FILL,
                      np.dtype(np.float64): Constants.DEFAULT_FILL_DOUBLE
                      }
 
-if np_version < Version('2.0'):
-    _DEFAULT_FILL_MAP[np.float_] = Constants.Constants.DEFAULT_FILL_DOUBLE
+try:
+    _DEFAULT_FILL_MAP[np.dtype(np.float_)] = Constants.DEFAULT_FILL_DOUBLE
+except AttributeError:
+    pass
 
 if version_info >= (3, ):
     _DEFAULT_FILL_MAP[np.int_] = Constants.DEFAULT_FILL_INT64

--- a/test/ci_tests/utests.py
+++ b/test/ci_tests/utests.py
@@ -107,7 +107,7 @@ def make_interp_test(varname, wrf_in, referent, multi=False,
             # print (hts_850)
             hts_850 = interplevel(hts, p, 850)
 
-            nt.assert_allclose(to_np(hts_850), ref_ht_850)
+            nt.assert_allclose(to_np(hts_850), ref_ht_850, rtol=1e-06)
 
         elif (varname == "vertcross"):
             ref_ht_cross = _get_refvals(referent, "vertcross", repeat, multi)


### PR DESCRIPTION
Running with NumPy 2.2.2 produces the following error:

    AttributeError: `np.float_` was removed in the NumPy 2.0 release. Use `np.float64` instead.

This removes the unsupported type.