### PR TITLE
Interpolation subroutine

### DIFF
--- a/fortran/wrf_user.f90
+++ b/fortran/wrf_user.f90
@@ -105,7 +105,7 @@ SUBROUTINE DINTERP3DZ(data3d, out2d, zdata, levels, nx, ny, nz, nlev, missingval
                 desiredloc = levels(lev)
 
                 DO WHILE ((.NOT. dointerp) .AND. (kp >= 2))
-                    IF (((zdata(i,j,kp-im) < desiredloc) .AND. (zdata(i,j,kp-ip) > desiredloc))) THEN
+                    IF (((zdata(i,j,kp-im) < desiredloc) .AND. (zdata(i,j,kp-ip) >= desiredloc))) THEN
                         w2 = (desiredloc - zdata(i,j,kp-im))/(zdata(i,j,kp-ip) - zdata(i,j,kp-im))
                         w1 = 1.D0 - w2
                         out2d(i,j,lev) = w1*data3d(i,j,kp-im) + w2*data3d(i,j,kp-ip)


### PR DESCRIPTION
The interpolation subroutine has been fixed to prevent NaN values when the desired interpolation level matches a data level.