### PR TITLE
GitHub Actions workflow updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,54 +9,41 @@ on:
   schedule:
     - cron: '0 0 * * *' # Daily “At 00:00”
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
-    name: Python (${{ matrix.python-version }}, ${{ matrix.os }})
+    name: Python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     defaults:
       run:
         shell: bash -l {0}
-
     strategy:
       fail-fast: false
       matrix:
         os: [ "ubuntu-latest", "macos-latest", "macos-14" ]
         python-version: [ "3.9", "3.10", "3.11", "3.12" ]
-
     steps:
-      - name: Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.12.1
-        with:
-          access_token: ${{ github.token }}
-      - name: Checkout
+      - name: checkout
         uses: actions/checkout@v4
-        with:
-          token: ${{ github.token }}
-      - name: Conda setup
-        uses: conda-incubator/setup-miniconda@v3
-        if: matrix.os != 'macos-14'
+      - name: environment setup
+        uses: conda-incubator/setup-miniconda@505e6394dae86d6a5c7fbb6e3fb8938e3e863830 # v3.1.1
         with:
           python-version: ${{ matrix.python-version }}
           channels: conda-forge
           environment-file: build_envs/environment.yml
-      - name: Conda setup (macOS M1)
-        uses: conda-incubator/setup-miniconda@v3
-        if: matrix.os == 'macos-14'
-        with:
-          installer-url: https://github.com/conda-forge/miniforge/releases/download/23.11.0-0/Mambaforge-23.11.0-0-MacOSX-arm64.sh
-          python-version: ${{ matrix.python-version }}
-          channels: conda-forge
-          environment-file: build_envs/environment.yml
-      - name: Build WRF-Python
+      - name: build WRF-Python
         run: |
           python -m pip install build
           python -m build .
           python -m pip install dist/wrf*.whl
-      - name: Run tests
+      - name: run tests
         run: |
           cd test/ci_tests
           python utests.py
-      - name: Check import
+      - name: check import
         if: failure()
         run: |
           python -m pip show wrf-python

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -12,15 +12,14 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: '3.10'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install setuptools setuptools-scm wheel twine check-manifest
+          python -m pip install build twine
       - name: Build tarball and wheels
         run: |
-          python setup.py sdist bdist_wheel
-          python -m pip wheel . -w dist --no-deps
+          python -m build
       - name: Test the artifacts
         run: |
           python -m twine check dist/*
@@ -33,20 +32,19 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: '3.10'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install setuptools setuptools-scm wheel twine check-manifest
+          python -m pip install build twine
       - name: Build tarball and wheels
         run: |
-          python setup.py sdist bdist_wheel
-          python -m pip wheel . -w dist --no-deps
+          python -m build
       - name: Test the artifacts
         run: |
           python -m twine check dist/*
       - name: Publish package to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.12.4
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
         with:
           user: __token__
           password: ${{ secrets.PYPI_WRF_PYTHON }}


### PR DESCRIPTION
Updates GitHub Actions workflows to pin to commit hashes for third party actions and updates the build steps in the PyPI workflow so that we're no longer directly calling `setup.py` (now deprecated).

Closes #268 