### PR TITLE
Remove pkg_resources

### DIFF
--- a/build_envs/environment.yml
+++ b/build_envs/environment.yml
@@ -11,9 +11,7 @@ dependencies:
   - matplotlib
   - netcdf4
   - numpy
-  - packaging
   - pycodestyle
-  - setuptools
   - sphinx
   - sphinx_rtd_theme
   - sphinxcontrib-googleanalytics

--- a/src/wrf/__init__.py
+++ b/src/wrf/__init__.py
@@ -2,24 +2,8 @@ from __future__ import (absolute_import, division, print_function)
 import os
 import pkg_resources
 
-try:
-    from . import api
-    from .api import *
-except ImportError:
-    # For gfortran+msvc combination, extra shared libraries may exist
-    # (stored by numpy.distutils)
-    if os.name == "nt":
-        req = pkg_resources.Requirement.parse("wrf-python")
-        extra_dll_dir = pkg_resources.resource_filename(req,
-                                                        "wrf-python/.libs")
-        if os.path.isdir(extra_dll_dir):
-            os.environ["PATH"] += os.pathsep + extra_dll_dir
-
-        from . import api
-        from .api import *
-    else:
-        raise
-
+from . import api
+from .api import *
 
 __all__ = []
 __all__.extend(api.__all__)

--- a/src/wrf/__init__.py
+++ b/src/wrf/__init__.py
@@ -1,6 +1,5 @@
 from __future__ import (absolute_import, division, print_function)
 import os
-import pkg_resources
 
 from . import api
 from .api import *


### PR DESCRIPTION
Removes deprecated `pkg_resources`.

This shouldn't cause any problems for the Linux or macOS builds since it was originally used as a workaround for some Windows specific issues tied to `np.distutils`.  And we no longer rely upon `distutils` so in theory removing this shouldn't be an issue there either. Unfortunately, we don't have testing for Windows, but we also aren't releasing Windows builds at the moment either.

I'll make sure we have an issue open for Windows testing / releases, but I'm inclined to get this merged without that and hopefully prioritize that soon. 

Closes #280 