### PR TITLE
Fix to handle recent netcdf4-python iterator changes

### DIFF
--- a/src/wrf/util.py
+++ b/src/wrf/util.py
@@ -9,6 +9,7 @@ from itertools import product, tee
 from types import GeneratorType
 import datetime as dt
 from inspect import getmodule
+from netCDF4 import Dataset
 
 try:
     from inspect import signature
@@ -134,10 +135,11 @@ def is_multi_file(wrfin):
         is a single NetCDF file object.
 
     """
-    try:
-        iter(wrfin)
+    if isinstance(wrfin, Dataset):
+        is_iterable = False
+    elif isinstance(wrfin, Iterable):
         is_iterable = True
-    except Exception:
+    else:
         is_iterable = False
 
     return (is_iterable and not isstr(wrfin))


### PR DESCRIPTION
In the latest release netcdf4-python added an `__iter__` method that raises a not implemented error to `Dataset` objects.  Unfortunately this makes them look like an `Iterable` changing some behavior in wrf-python and ultimately resulting in an error.  

This is a bit of a clunky fix, but it should do the trick.

Closes #290 